### PR TITLE
Fix ReferenceError: require is not defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@ import Crawler from "./Crawler.js";
 import logger from "./helpers/logger.js";
 // import Spinnies from "dreidels";
 // const ms = new Spinnies()
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 
 import Spinnies from 'dreidels'
 const ms = new Spinnies.default()


### PR DESCRIPTION
This fixes the following error when you invoke ccdown with the following options:

ccdown
✔ Do you want all courses? … yes
✔ Do you want download from a file … yes
✔ Enter a file path eg: /opt/homebrew/lib/node_modules/ccdown/json/*.json  › my_courses.json ✔ Enter email … valid_email@gmail.com
✔ Enter password … ******
✔ Enter a directory to save a file (eg: /Users/kp/Code/web/_course_downloaders/ccdown) … /Users/kp/Code/web/_course_downloaders/ccdown/videos ✔ Login...  completed.
MAIN errorr in cli.js: ReferenceError: require is not defined
    at all (file:///opt/homebrew/lib/node_modules/ccdown/lib/index.js:23:19)